### PR TITLE
Add 404 retry to GitHub API client for consistency issues

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,49 @@
+name: Build and Push to Artifact Registry
+
+on:
+  push:
+    branches:
+      - "master"
+  pull_request:
+
+jobs:
+  docker:
+    permissions:
+      contents: read
+      id-token: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: us-east4-docker.pkg.dev/dev-inf-prod/bors-ng/bors-ng
+          tags: |
+            type=sha,format=long,prefix=
+      - name: Authenticate to Google Cloud
+        id: 'auth'
+        uses: google-github-actions/auth@v2
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'cockroachlabs/bors-ng'}}
+        with:
+          token_format: access_token
+          workload_identity_provider: "projects/72497726731/locations/global/workloadIdentityPools/bors-ng-github-oidc/providers/bors-ng-github-oidc"
+          service_account: "bors-ng-github@dev-inf-prod.iam.gserviceaccount.com"
+      - name: Login to Google Artifacts Repository
+        uses: docker/login-action@v3
+        if: ${{ github.event_name != 'pull_request' && github.repository == 'cockroachlabs/bors-ng'}}
+        with:
+          registry: us-east4-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.auth.outputs.access_token }}
+      - name: Build and maybe push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          push: ${{ github.event_name != 'pull_request' && github.repository == 'cockroachlabs/bors-ng'}}
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-ARG ELIXIR_VERSION=1.14.5
+# Use 1.13.4 to match the glibc version used in the target image
+ARG ELIXIR_VERSION=1.13.4
 ARG SOURCE_COMMIT
 
 FROM elixir:${ELIXIR_VERSION} as builder
@@ -9,7 +10,7 @@ RUN apt-get update -q && apt-get --no-install-recommends install -y apt-utils ca
 
 RUN DEBIAN_CODENAME=$(sed -n 's/VERSION=.*(\(.*\)).*/\1/p' /etc/os-release) && \
     curl -q https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add - && \
-    echo "deb http://deb.nodesource.com/node_12.x $DEBIAN_CODENAME main" | tee /etc/apt/sources.list.d/nodesource.list && \
+    echo "deb http://deb.nodesource.com/node_20.x $DEBIAN_CODENAME main" | tee /etc/apt/sources.list.d/nodesource.list && \
     apt-get update -q && \
     apt-get --no-install-recommends install -y nodejs
 

--- a/lib/github/github/server.ex
+++ b/lib/github/github/server.ex
@@ -966,7 +966,14 @@ defmodule BorsNG.GitHub.Server do
          {"accept", content_type},
          {"user-agent", "bors-ng https://bors.tech"}
        ]},
-      {Tesla.Middleware.Retry, delay: 100, max_retries: 5}
+      {Tesla.Middleware.Retry,
+       delay: 100,
+       max_retries: 5,
+       should_retry: fn
+         {:ok, %{status: status}} when status in [404, 500, 502, 503, 504] -> true
+         {:ok, %{status: _}} -> false
+         {:error, _} -> true
+       end}
     ]
 
     middleware =


### PR DESCRIPTION
GitHub API sometimes returns 404 errors due to eventual consistency issues during batch operations. Adding 404 to the retry list along with existing 5xx server errors to handle these transient failures.

Downgrade Elixir to 1.13.4 in Dockerfile to match glibc version of the target image.

Add CI workflow to build and push Docker images to Google Artifact Registry.